### PR TITLE
Update Style Transfer notebook

### DIFF
--- a/Style Transfer/style_transfer.ipynb
+++ b/Style Transfer/style_transfer.ipynb
@@ -40,9 +40,12 @@
    },
    "outputs": [],
    "source": [
-    "%pip install -q numpy==1.18.2 opencv-python-headless==4.2.0.32 \\\n",
-    "    torch==1.4.0 torchvision==0.5.0 folium==0.2.1 \\\n",
-    "    albumentations==0.4.5 tqdm==4.43.0 matplotlib==3.2.0 "
+    "if 'google.colab' in str(get_ipython()):\n",
+    "    print('Skipping pip installation on Google Colab')\n",
+    "else:\n",
+    "    %pip install -q numpy==1.18.2 opencv-python-headless==4.2.0.32 \\\n",
+    "        torch==1.4.0 torchvision==0.5.0 folium==0.2.1 \\\n",
+    "        albumentations==0.4.5 tqdm==4.43.0 matplotlib==3.2.0 "
    ]
   },
   {


### PR DESCRIPTION
Update Style Transfer notebook to skip pip install on Google Colab